### PR TITLE
Fix for issue #75

### DIFF
--- a/repository/Squeak.v3.package/NumberParser.class/class/defaultParserClass..st
+++ b/repository/Squeak.v3.package/NumberParser.class/class/defaultParserClass..st
@@ -1,0 +1,3 @@
+instance creation
+defaultParserClass: aClass
+	DefaultParserClass := aClass

--- a/repository/Squeak.v3.package/NumberParser.class/class/defaultParserClass.st
+++ b/repository/Squeak.v3.package/NumberParser.class/class/defaultParserClass.st
@@ -1,0 +1,4 @@
+instance creation
+defaultParserClass
+	DefaultParserClass ifNil: [ DefaultParserClass := SqNumberParser ].
+ 	^ DefaultParserClass

--- a/repository/Squeak.v3.package/NumberParser.class/class/on..st
+++ b/repository/Squeak.v3.package/NumberParser.class/class/on..st
@@ -1,3 +1,3 @@
 instance creation
 on: aStringOrStream
-	^self new on: aStringOrStream
+	^self defaultParserClass new on: aStringOrStream

--- a/repository/Squeak.v3.package/NumberParser.class/class/parse..st
+++ b/repository/Squeak.v3.package/NumberParser.class/class/parse..st
@@ -1,5 +1,5 @@
 instance creation
 parse: aStringOrStream 
-	^(self new)
+	^(self defaultParserClass new)
 		on: aStringOrStream;
 		nextNumber

--- a/repository/Squeak.v3.package/NumberParser.class/class/parse.onError..st
+++ b/repository/Squeak.v3.package/NumberParser.class/class/parse.onError..st
@@ -1,6 +1,6 @@
 instance creation
 parse: aStringOrStream onError: failBlock 
-	^(self new)
+	^(self defaultParserClass new)
 		on: aStringOrStream;
 		failBlock: failBlock;
 		nextNumber

--- a/repository/Squeak.v3.package/NumberParser.class/methodProperties.json
+++ b/repository/Squeak.v3.package/NumberParser.class/methodProperties.json
@@ -1,8 +1,10 @@
 {
 	"class" : {
-		"on:" : "nice 5/1/2006 00:45",
-		"parse:" : "nice 5/1/2006 02:02",
-		"parse:onError:" : "nice 5/1/2006 02:02",
+		"defaultParserClass" : "IwanVosloo 09/15/2015 01:03",
+		"defaultParserClass:" : "IwanVosloo 09/15/2015 01:18",
+		"on:" : "IwanVosloo 09/15/2015 00:58",
+		"parse:" : "IwanVosloo 09/15/2015 01:03",
+		"parse:onError:" : "IwanVosloo 09/15/2015 01:04",
 		"squeezeNumberOutOfString:" : "NikoSchwarz 10/23/2009 13:21",
 		"squeezeNumberOutOfString:onError:" : "NikoSchwarz 10/23/2009 13:22" },
 	"instance" : {

--- a/repository/Squeak.v3.package/NumberParser.class/properties.json
+++ b/repository/Squeak.v3.package/NumberParser.class/properties.json
@@ -3,7 +3,7 @@
 	"classinstvars" : [
 		 ],
 	"classvars" : [
-		 ],
+		"DefaultParserClass" ],
 	"commentStamp" : "nice 2/13/2010 00:31",
 	"instvars" : [
 		"sourceStream",

--- a/repository/Squeak.v3.package/NumberParserTest.class/instance/testDefaultParserClassIsSqNumberParser.st
+++ b/repository/Squeak.v3.package/NumberParserTest.class/instance/testDefaultParserClassIsSqNumberParser.st
@@ -1,0 +1,7 @@
+as yet unclassified
+testDefaultParserClassIsSqNumberParser
+	"The defaultParserClass of NumberParser is SqNumberParser, but can be changed"
+	
+	self assert: NumberParser defaultParserClass == SqNumberParser.
+	NumberParser defaultParserClass: ExtendedNumberParser.
+	self assert: NumberParser defaultParserClass == ExtendedNumberParser.

--- a/repository/Squeak.v3.package/NumberParserTest.class/instance/testDefaultParserClassIsUsed.st
+++ b/repository/Squeak.v3.package/NumberParserTest.class/instance/testDefaultParserClassIsUsed.st
@@ -1,0 +1,7 @@
+as yet unclassified
+testDefaultParserClassIsUsed
+	"NumberParser class methods default to using a concrete default parser class"
+	
+	self assert: (NumberParser on: '123') class == NumberParser defaultParserClass.
+	self assert: (NumberParser parse: '123') = 123.
+	self assert: (NumberParser parse: '123' onError: [ nil ]) = 123.

--- a/repository/Squeak.v3.package/NumberParserTest.class/methodProperties.json
+++ b/repository/Squeak.v3.package/NumberParserTest.class/methodProperties.json
@@ -1,0 +1,6 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"testDefaultParserClassIsSqNumberParser" : "IwanVosloo 09/15/2015 01:17",
+		"testDefaultParserClassIsUsed" : "IwanVosloo 09/15/2015 01:18" } }

--- a/repository/Squeak.v3.package/NumberParserTest.class/properties.json
+++ b/repository/Squeak.v3.package/NumberParserTest.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "Squeak-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "NumberParserTest",
+	"pools" : [
+		 ],
+	"super" : "TestCase",
+	"type" : "normal" }


### PR DESCRIPTION
Changed NumberParser class methods to be able to be used as if NumberParser were a concrete class, using a defaultParserClass (fixes #75)
