### PR TITLE
Fix SmallTime>>asDuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,8 @@ name: smalltalkCI
 on:
   push:
     branches:
-      - "*"
   pull_request:
     branches:
-      - master
   workflow_dispatch:
   schedule:
     - cron: "15 2 12 * *" #run job on the 12th day of every month on the 15th minute of the 2nd hour

--- a/repository/Squeak.v36.package/Time.extension/instance/asDuration.st
+++ b/repository/Squeak.v36.package/Time.extension/instance/asDuration.st
@@ -1,4 +1,4 @@
 *squeak
 asDuration
 
-	^milliseconds asDuration
+	^ self asMilliseconds asDuration

--- a/repository/Squeak.v37.package/Time.extension/instance/asDuration.st
+++ b/repository/Squeak.v37.package/Time.extension/instance/asDuration.st
@@ -1,4 +1,4 @@
 *squeak
 asDuration
 
-	^milliseconds asDuration
+	^ self asMilliseconds asDuration


### PR DESCRIPTION
Fix issue 144 (https://github.com/GsDevKit/GsDevKit/issues/144): instances of SmallTime subclass do not have the instvar milliseconds. 

I took the approach by changing the inherited method rather than overriding it.