### PR TITLE
Fix float parsing in GemStone.

### DIFF
--- a/repository/Squeak.v37.package/SqNumberParser.class/instance/makeIntegerOrScaledInteger.st
+++ b/repository/Squeak.v37.package/SqNumberParser.class/instance/makeIntegerOrScaledInteger.st
@@ -6,7 +6,10 @@ makeIntegerOrScaledInteger
 	neg
 		ifTrue: [integerPart := integerPart negated].
 	self readExponent
-		ifTrue: [^integerPart * (base raisedToInteger: exponent)].
+		ifTrue:
+      [^exponent negative "GemStone now returns a fraction instead of a float. We want a float for negative exponents."
+        ifTrue: [integerPart * (base asFloat raisedToInteger: exponent)]
+        ifFalse: [integerPart * (base raisedToInteger: exponent)]].
 	self readScale
 		ifTrue: [^integerPart asScaledDecimal: scale].
 	^ integerPart


### PR DESCRIPTION
GemStone 3.7.2 changed the behavior of `1 raisedToInteger: -3` to return a fraction instead of a float. This update ensure that a float is returned.

This commit resolves https://github.com/dalehenrich/rb/issues/12