### PR TITLE
Updating Sport library definition from Monticello (file) to Metacello (github)

### DIFF
--- a/repository/BaselineOfGLASS1.package/BaselineOfGLASS1.class/instance/baseline..st
+++ b/repository/BaselineOfGLASS1.package/BaselineOfGLASS1.class/instance/baseline..st
@@ -52,7 +52,6 @@ baseline: spec
 				package: 'GemStone-Indexing-Extensions'
 					with: [ spec requires: #('Bootstrap') ];
 				package: 'GemStone-Release-Support' with: [ spec requires: #('GsCore') ];
-				package: 'Sport' with: [ spec requires: #('Bootstrap') ];
 				package: 'Squeak' with: [ spec requires: #('Sport') ];
 				package: 'Regex-Core' with: [ spec requires: #('Core' 'Squeak') ];
 				package: 'Regex-Tests-Core' with: [ spec requires: #('Regex-Core') ];

--- a/repository/BaselineOfGLASS1.package/BaselineOfGLASS1.class/instance/baseline..st
+++ b/repository/BaselineOfGLASS1.package/BaselineOfGLASS1.class/instance/baseline..st
@@ -25,6 +25,8 @@ baseline: spec
 				project: 'Grease-Tests' copyFrom: 'Grease' with: [ spec loads: #('Tests') ];
 				baseline: 'Metacello'
 					with: [ spec repository: 'github://dalehenrich/metacello-work:master/repository' ];
+				baseline: 'Sport'
+					with: [ spec repository: 'github://GsDevKit:master/Sport/src' ];
 				configuration: 'XMLSupport'
 					with: [ 
 							spec
@@ -50,12 +52,7 @@ baseline: spec
 				package: 'GemStone-Indexing-Extensions'
 					with: [ spec requires: #('Bootstrap') ];
 				package: 'GemStone-Release-Support' with: [ spec requires: #('GsCore') ];
-				package: 'Sport'
-					with: [ 
-							spec
-								file: 'Sport3.010-dkh.38';
-								requires: #('Bootstrap');
-								repository: 'http://seaside.gemtalksystems.com/ss/hyper' ];
+				package: 'Sport' with: [ spec requires: #('Bootstrap') ];
 				package: 'Squeak' with: [ spec requires: #('Sport') ];
 				package: 'Regex-Core' with: [ spec requires: #('Core' 'Squeak') ];
 				package: 'Regex-Tests-Core' with: [ spec requires: #('Regex-Core') ];

--- a/repository/BaselineOfGLASS1.package/BaselineOfGLASS1.class/instance/baseline..st
+++ b/repository/BaselineOfGLASS1.package/BaselineOfGLASS1.class/instance/baseline..st
@@ -193,7 +193,6 @@ baseline: spec
 				package: 'OB-Standard' with: [ spec file: 'OB-Standard.v3' ];
 				package: 'OB-SymbolListBrowser' with: [ spec requires: #('OB-Standard') ];
 				package: 'OB-Tools' with: [ spec file: 'OB-Tools.v3' ];
-				package: 'Sport' with: [ spec file: 'Sport3.010.v3-jupiter.33' ];
 				package: 'Squeak' with: [ spec file: 'Squeak.v3' ];
 				yourself.
 			spec

--- a/repository/BaselineOfGLASS1.package/BaselineOfGLASS1.class/instance/baseline..st
+++ b/repository/BaselineOfGLASS1.package/BaselineOfGLASS1.class/instance/baseline..st
@@ -26,7 +26,7 @@ baseline: spec
 				baseline: 'Metacello'
 					with: [ spec repository: 'github://dalehenrich/metacello-work:master/repository' ];
 				baseline: 'Sport'
-					with: [ spec repository: 'github://GsDevKit:master/Sport/src' ];
+					with: [ spec repository: 'github://GsDevKit/Sport:master/src' ];
 				configuration: 'XMLSupport'
 					with: [ 
 							spec


### PR DESCRIPTION
Updating baseline for Glass1 in case of Sport compatibility layer to use github instead of Monticello's file.

The main issue addressed here is that the Sport dependency using Monticello can't be influenced by Metacello loading sequence.  This update prevents loading the Sport library via http and uses GsDevKit github mirror instead.